### PR TITLE
Download/unzip files locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@ serf
 Ansible role for [serf](http://www.serfdom.io/).
 This role ensures that serf runs as a daemon.
 
-Requirements
-------------
-- unzip command on remote hosts
-
 Role Variables
 --------------
 - version

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,8 @@
 ---
-# handlers for serf
+- name: Remove temp files
+  file: path={{ item }} state=absent
+  with_items:
+    - /tmp/serf
+    - /tmp/{{ version }}_linux_amd64.zip
+  delegate_to: localhost
+  ignore_errors: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,8 +9,13 @@
     dest: /tmp
     mode: 0644
     sha256sum: "{{ sha256sum }}"
+  delegate_to: localhost
 
-- command: unzip -o /tmp/{{ version }}_linux_amd64.zip chdir=/usr/local/bin
+- unarchive: src=/tmp/{{ version }}_linux_amd64.zip dest=/tmp
+  delegate_to: localhost
+  notify: Remove temp files
+
+- copy: src=/tmp/serf dest=/usr/local/bin/serf owner=serf group=serf mode=0755
 
 - file: path=/usr/local/bin/serf owner=serf group=serf mode=0755 state=file
 


### PR DESCRIPTION
so we only download once, even if deploying to many hosts. Also this cleans up temporary files.
